### PR TITLE
Fix empty constructor toggling issue by adding "_" in css

### DIFF
--- a/webshow.css
+++ b/webshow.css
@@ -67,3 +67,7 @@ label:hover * {
   color: white;
   cursor: pointer;
 }
+
+label > span:empty::after {
+    content: "_"
+}


### PR DESCRIPTION
Constructor with an empty name generate a empty label which can't be selected
to control the expansion of the data.
This happen for example with `Day`.

This solution just uses css rules to display _ when the span is empty.